### PR TITLE
Changed the logic for sorting lower and capital letters to ignore them.

### DIFF
--- a/sort_dbt_docs/sort.py
+++ b/sort_dbt_docs/sort.py
@@ -46,7 +46,7 @@ def _sort_markdown(markdown_text: str) -> str:
     """
     pattern = r"{% docs (.+?) %}(.*?){% enddocs %}"
     docs_blocks = re.findall(pattern, markdown_text, flags=re.DOTALL)
-    sorted_docs_blocks = sorted(docs_blocks, key=lambda x: x[0])
+    sorted_docs_blocks = sorted(docs_blocks, key=lambda x: x[0].lower())
 
     # Add the sorted docs to a new string so that this can be written back to the file.
     sorted_markdown = ""
@@ -91,5 +91,4 @@ def main():
 
 
 if __name__ == "__main__":  # pragma: no cover
-    args = _parse_arguments()
-    raise SystemExit(sort(args))
+    main()

--- a/tests/testdata/cap_low_docs.md
+++ b/tests/testdata/cap_low_docs.md
@@ -1,4 +1,4 @@
-{% docs A %}Documentation for A.
+{% docs X %}Documentation for X.
 {% enddocs %}
 {% docs a %}
 Documentation for a.

--- a/tests/testdata/expected_cap_low_docs.md
+++ b/tests/testdata/expected_cap_low_docs.md
@@ -1,15 +1,15 @@
-{% docs A %}
-Documentation for A.
-{% enddocs %}
-
-{% docs Aa %}
-Documentation for Aa.
-{% enddocs %}
-
 {% docs a %}
 Documentation for a.
 {% enddocs %}
 
 {% docs aA %}
 Documentation for aA.
+{% enddocs %}
+
+{% docs Aa %}
+Documentation for Aa.
+{% enddocs %}
+
+{% docs X %}
+Documentation for X.
 {% enddocs %}


### PR DESCRIPTION
Otherwise capital letters will always be sorted to the beginning of the file, even if they start with a letter that comes alphabetically after the lowercase letter.